### PR TITLE
Add c2hs to build-tools in .cabal file

### DIFF
--- a/phone-numbers.cabal
+++ b/phone-numbers.cabal
@@ -42,6 +42,9 @@ library
     base == 4.*,
     bytestring
 
+  build-tools:
+    c2hs
+
   ghc-options: -Wall
 
 source-repository head


### PR DESCRIPTION
This makes it a dependency so it'll automatically be built.