### PR TITLE
Add protobuf C library as a dependency

### DIFF
--- a/phone-numbers.cabal
+++ b/phone-numbers.cabal
@@ -26,7 +26,7 @@ library
   c-sources:
     cbits/phone-numbers.cc
 
-  extra-libraries: phonenumber, stdc++
+  extra-libraries: phonenumber, stdc++, protobuf
 
   include-dirs:
     include


### PR DESCRIPTION
On my machine, phone-numbers was failing to build because it wasn't linking
the protobuf C library. I don't understand why it works on other people's
machines. Anyway, this fixes it for me and should be harmless for everyone
else.

It'd be awesome if you uploaded a new release to Hackage after merging this :)