### PR TITLE
Brechtserckx/feature/errortype

### DIFF
--- a/include/c-phone-numbers.h
+++ b/include/c-phone-numbers.h
@@ -54,6 +54,15 @@ enum PhoneNumberFormat {
     RFC3966
 };
 
+enum ErrorType {
+                NO_PARSING_ERROR,
+                INVALID_COUNTRY_CODE_ERROR,  // INVALID_COUNTRY_CODE in the java version.
+                NOT_A_NUMBER,
+                TOO_SHORT_AFTER_IDD,
+                TOO_SHORT_NSN,
+                TOO_LONG_NSN,  // TOO_LONG in the java version.
+};
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/lib/Data/PhoneNumber/FFI.chs
+++ b/lib/Data/PhoneNumber/FFI.chs
@@ -5,6 +5,7 @@ module Data.PhoneNumber.FFI (
     PhoneNumberUtil(..),
     PhoneNumberType(..),
     PhoneNumberFormat(..),
+    PhoneNumberParseError(..),
 
     -- * Parsing and utility
     c_phone_number_ctor,
@@ -45,6 +46,8 @@ data PhoneNumberUtil = PhoneNumberUtil { unPhoneNumberUtil :: Ptr PhoneNumberUti
 {# enum PhoneNumberType as PhoneNumberType {underscoreToCase} deriving (Eq, Show) #}
 
 {# enum PhoneNumberFormat as PhoneNumberFormat {underscoreToCase} deriving (Eq, Show) #}
+
+{# enum ErrorType as PhoneNumberParseError {underscoreToCase} deriving (Eq, Show) #}
 
 --  | Create a PhoneNumber opaque pointer
 foreign import ccall unsafe "c-phone-numbers.h _c_phone_number_ctor"

--- a/lib/Data/PhoneNumber/FFI.chs
+++ b/lib/Data/PhoneNumber/FFI.chs
@@ -47,7 +47,7 @@ data PhoneNumberUtil = PhoneNumberUtil { unPhoneNumberUtil :: Ptr PhoneNumberUti
 
 {# enum PhoneNumberFormat as PhoneNumberFormat {underscoreToCase} deriving (Eq, Show) #}
 
-{# enum ErrorType as PhoneNumberParseError {underscoreToCase} deriving (Eq, Show) #}
+{# enum ErrorType as PhoneNumberParseError {underscoreToCase} omit (NO_PARSING_ERROR) deriving (Eq, Show) #}
 
 --  | Create a PhoneNumber opaque pointer
 foreign import ccall unsafe "c-phone-numbers.h _c_phone_number_ctor"

--- a/lib/Data/PhoneNumber/LowLevel.hs
+++ b/lib/Data/PhoneNumber/LowLevel.hs
@@ -92,9 +92,9 @@ parsePhoneNumber (PhoneNumberUtil util_ptr) (PhoneNumberRef f_ptr) number region
     useAsCStringLen region $ \(region_str, fromIntegral -> region_len) -> do
     retco <- withForeignPtr f_ptr $
         c_phone_number_util_parse util_ptr number_str number_len region_str region_len
-    return $ case toEnum . fromIntegral $ retco of
-      NoParsingError -> Right ()
-      err -> Left err
+    return $ case fromIntegral $ retco of
+      0 -> Right ()
+      err -> Left . toEnum $ err - 1
 
 -- | Read the country code from a PhoneNumberRef
 getCountryCode :: PhoneNumberRef -> IO (Maybe Word64)

--- a/lib/Data/PhoneNumber/LowLevel.hs
+++ b/lib/Data/PhoneNumber/LowLevel.hs
@@ -50,12 +50,6 @@ import           Data.Word
 import           Foreign.ForeignPtr     (newForeignPtr, withForeignPtr)
 import           Foreign.Ptr            (Ptr, nullPtr)
 
--- | There was a problem parting your phone number. For now, if you want to
--- know what the Int here means, you'll need to look at the ErrorType enum in
--- the underlying library.
-data PhoneNumberParseError = PhoneNumberParseError Int
-  deriving (Eq, Show)
-
 -- | A data type representation of a phone number, you can build one of these
 -- with 'copyPhoneNumberRef' given a 'PhoneNumberRef', which is simply a
 -- convenience for a series of calls to accessors.
@@ -95,15 +89,12 @@ parsePhoneNumber
     -> IO (Either PhoneNumberParseError ())
 parsePhoneNumber (PhoneNumberUtil util_ptr) (PhoneNumberRef f_ptr) number region =
     useAsCStringLen number $ \(number_str, fromIntegral -> number_len) ->
-    useAsCStringLen region $ \(region_str, fromIntegral -> region_len) ->
-    withForeignPtr f_ptr $ \ptr -> do
-        e <- c_phone_number_util_parse util_ptr number_str number_len region_str region_len ptr
-        return $ checkError (fromIntegral e)
-  where
-    -- TODO: This is actually a an ErrorType enum, we could translate errors to
-    -- more useful ones.
-    checkError 0 = Right ()
-    checkError e = Left $ PhoneNumberParseError e
+    useAsCStringLen region $ \(region_str, fromIntegral -> region_len) -> do
+    retco <- withForeignPtr f_ptr $
+        c_phone_number_util_parse util_ptr number_str number_len region_str region_len
+    return $ case toEnum . fromIntegral $ retco of
+      NoParsingError -> Right ()
+      err -> Left err
 
 -- | Read the country code from a PhoneNumberRef
 getCountryCode :: PhoneNumberRef -> IO (Maybe Word64)


### PR DESCRIPTION
This PR replaces Int error codes by an enum for ParseErrors, by importing it with c2hs.