### PR TITLE
Fix build for GHC-8.10

### DIFF
--- a/phone-numbers.cabal
+++ b/phone-numbers.cabal
@@ -1,6 +1,7 @@
+cabal-version:  2.2
 name:           phone-numbers
 version:        0.2.0
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
 homepage:       https://github.com/christian-marie/phone-numbers
 bug-reports:    https://github.com/christian-marie/phone-numbers
@@ -9,7 +10,6 @@ author:         Christian Marie <christian@ponies.io>
 maintainer:     Christian Marie <christian@ponies.io>
 stability:      experimental
 synopsis:       Haskell bindings to the libphonenumber library
-cabal-version:  >= 1.8
 build-type:     Simple
 description:
     Basic phone number parsing, largely incomplete, please submit a pull
@@ -24,7 +24,7 @@ extra-source-files:
 library
   hs-source-dirs: lib
 
-  c-sources:
+  cxx-sources:
     cbits/phone-numbers.cc
 
   extra-libraries: phonenumber, stdc++, protobuf
@@ -47,7 +47,7 @@ library
     c2hs
 
   ghc-options: -Wall
-  cc-options:  -std=c++14
+  cxx-options:  -std=c++14
   
 source-repository head
   type:     git

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
 - '.'
 
 extra-deps: []
-resolver: lts-14.8
+resolver: nightly-2020-11-23
 
 nix:
   packages: [ libphonenumber, protobuf ]

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 524789
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/8.yaml
-    sha256: 8af5eb80734f02621d37e82cc0cde614af2ddc9c320610acb0b1b6d9ac162930
-  original: lts-14.8
+    size: 554194
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2020/11/23.yaml
+    sha256: d4037ffda88f024e83ce3e466d7b612939024f2e5d4895f8af7b4ff96cd7ea68
+  original: nightly-2020-11-23


### PR DESCRIPTION
This also needs a custom stack-version because of https://github.com/haskell/cabal/pull/7072#issuecomment-692917326.